### PR TITLE
Add coronavirus monitor env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+CORONAVIRUS_MONITOR_URL=https://coronavirus-monitor.p.rapidapi.com/coronavirus
+CORONAVIRUS_MONITOR_HOST=coronavirus-monitor.p.rapidapi.com
+CORONAVIRUS_MONITOR_KEY=f3aaada3fdmsh01752c4dfa674acp12ea76jsnfe30e4023c44

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # projectAvalon
+
+### Setup
+
+Before running the application, create the `.env` file with the content of `.env.example`. You may change the values if you want to a different local configuration.

--- a/bot.js
+++ b/bot.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 
 dotenv.config();
-const URL = 'https://coronavirus-monitor.p.rapidapi.com/coronavirus/';
+const URL = process.env.CORONAVIRUS_MONITOR_URL;
 const countryList = ['Brazil', 'Italy', 'Iran', 'USA', 'China', 'Spain', 'Germany', 'France', 'UK', 'Canada', 'Portugal', 'Australia', 'Argentina', 'Venezuela', 'S. Korea', 'Ecuador'];
 
 const Twit = require('twit');
@@ -25,8 +25,8 @@ const TLite = new TwitterLite(configLite);
 const axiosConfig = {
   method: 'GET',
   headers: {
-    'x-rapidapi-host': 'coronavirus-monitor.p.rapidapi.com',
-    'x-rapidapi-key': 'f3aaada3fdmsh01752c4dfa674acp12ea76jsnfe30e4023c44',
+    'x-rapidapi-host': process.env.CORONAVIRUS_MONITOR_HOST,
+    'x-rapidapi-key': process.env.CORONAVIRUS_MONITOR_KEY,
   },
 };
 

--- a/bot.js
+++ b/bot.js
@@ -46,7 +46,7 @@ async function getCorona(conf) {
 }
 
 async function getCasesByCountry() {
-  axiosConfig.url = `${URL}cases_by_country.php`;
+  axiosConfig.url = `${URL}/cases_by_country.php`;
   axiosConfig.responseType = '';
   const response = await getCorona(axiosConfig);
   return response.countries_stat;
@@ -78,7 +78,7 @@ async function getRandomMask64() {
   const pathFile = path.resolve(__dirname, 'images', 'maskTmp.jpg');
   const writer = fs.createWriteStream(pathFile);
 
-  axiosConfig.url = `${URL}random_masks_usage_instructions.php`;
+  axiosConfig.url = `${URL}/random_masks_usage_instructions.php`;
   axiosConfig.responseType = 'stream';
 
   const response = await getCorona(axiosConfig);


### PR DESCRIPTION
## Description

This PR adds the followinging env variables for `CORONAVIRUS_MONITOR`:

- Add CORONAVIRUS_MONITOR_URL
- Add CORONAVIRUS_MONITOR_HOST
- Add CORONAVIRUS_MONITOR_KEY